### PR TITLE
remove elastic alerts

### DIFF
--- a/src/main/java/org/team5924/frc2025/subsystems/drive/Drive.java
+++ b/src/main/java/org/team5924/frc2025/subsystems/drive/Drive.java
@@ -110,11 +110,11 @@ public class Drive extends SubsystemBase {
   private final Alert gyroDisconnectedAlert =
       new Alert("Disconnected gyro, using kinematics as fallback.", AlertType.kError);
 
-  private final Notification gyroDisconnectedNotification =
-      new Notification(
-          NotificationLevel.ERROR,
-          "Gyro Disconnected",
-          "Disconnected gyro, using kinematics as fallback.");
+  // private final Notification gyroDisconnectedNotification =
+  //     new Notification(
+  //         NotificationLevel.ERROR,
+  //         "Gyro Disconnected",
+  //         "Disconnected gyro, using kinematics as fallback.");
 
   boolean isFlipped =
       DriverStation.getAlliance().isPresent() && DriverStation.getAlliance().get() == Alliance.Red;
@@ -282,8 +282,8 @@ public class Drive extends SubsystemBase {
     // Update gyro alert
     gyroDisconnectedAlert.set(!gyroInputs.connected && Constants.currentMode != Mode.SIM);
 
-    if (!gyroInputs.connected && Constants.currentMode != Mode.SIM)
-      Elastic.sendNotification(gyroDisconnectedNotification);
+    // if (!gyroInputs.connected && Constants.currentMode != Mode.SIM)
+    //   Elastic.sendNotification(gyroDisconnectedNotification);
 
     // Update RobotState
     RobotState.getInstance().setOdometryPose(getPose());

--- a/src/main/java/org/team5924/frc2025/subsystems/elevator/Elevator.java
+++ b/src/main/java/org/team5924/frc2025/subsystems/elevator/Elevator.java
@@ -69,8 +69,8 @@ public class Elevator extends SubsystemBase {
   private final Alert leftMotorDisconnected;
   private final Alert rightMotorDisconnected;
 
-  private final Notification leftMotorDisconnectedNotification;
-  private final Notification rightMotorDisconnectedNotification;
+  // private final Notification leftMotorDisconnectedNotification;
+  // private final Notification rightMotorDisconnectedNotification;
 
   public Elevator(ElevatorIO io) {
     this.io = io;
@@ -82,13 +82,13 @@ public class Elevator extends SubsystemBase {
     this.rightMotorDisconnected =
         new Alert("Right elevator motor disconnected!", Alert.AlertType.kWarning);
 
-    leftMotorDisconnectedNotification =
-        new Notification(
-            NotificationLevel.WARNING, "Elevator Warning", "Left elevator motor disconnected!");
+    // leftMotorDisconnectedNotification =
+    //     new Notification(
+    //         NotificationLevel.WARNING, "Elevator Warning", "Left elevator motor disconnected!");
 
-    rightMotorDisconnectedNotification =
-        new Notification(
-            NotificationLevel.WARNING, "Elevator Warning", "Right elevator motor disconnected!");
+    // rightMotorDisconnectedNotification =
+    //     new Notification(
+    //         NotificationLevel.WARNING, "Elevator Warning", "Right elevator motor disconnected!");
 
     upSysId =
         new SysIdRoutine(

--- a/src/main/java/org/team5924/frc2025/subsystems/pivot/AlgaePivot.java
+++ b/src/main/java/org/team5924/frc2025/subsystems/pivot/AlgaePivot.java
@@ -55,7 +55,7 @@ public class AlgaePivot extends SubsystemBase {
 
   private final Alert AlgaePivotMotorDisconnected;
 
-  private final Notification algaePivotMotorDisconnectedNotification;
+  // private final Notification algaePivotMotorDisconnectedNotification;
 
   /** Creates a new AlgaePivot. */
   public AlgaePivot(AlgaePivotIO io) {
@@ -64,9 +64,9 @@ public class AlgaePivot extends SubsystemBase {
     this.AlgaePivotMotorDisconnected =
         new Alert("Algae pivot motor disconnected!", Alert.AlertType.kWarning);
 
-    algaePivotMotorDisconnectedNotification =
-        new Notification(
-            NotificationLevel.WARNING, "Algae Pivot Warning", "Algae Pivot motor disconnected!");
+    // algaePivotMotorDisconnectedNotification =
+    //     new Notification(
+    //         NotificationLevel.WARNING, "Algae Pivot Warning", "Algae Pivot motor disconnected!");
   }
 
   @Override

--- a/src/main/java/org/team5924/frc2025/subsystems/rollers/GenericRollerSystem.java
+++ b/src/main/java/org/team5924/frc2025/subsystems/rollers/GenericRollerSystem.java
@@ -49,7 +49,7 @@ public abstract class GenericRollerSystem<G extends GenericRollerSystem.VoltageS
   private final Alert disconnected;
   protected final Timer stateTimer = new Timer();
 
-  private final Notification disconnectedNotification;
+  // private final Notification disconnectedNotification;
 
   public GenericRollerSystem(String name, GenericRollerSystemIO io) {
     this.name = name;
@@ -57,9 +57,9 @@ public abstract class GenericRollerSystem<G extends GenericRollerSystem.VoltageS
 
     disconnected = new Alert(name + " motor disconnected!", Alert.AlertType.kWarning);
 
-    disconnectedNotification =
-        new Notification(
-            NotificationLevel.WARNING, name + " Warning", name + " motor disconnected!");
+    // disconnectedNotification =
+    //     new Notification(
+    //         NotificationLevel.WARNING, name + " Warning", name + " motor disconnected!");
 
     stateTimer.start();
   }


### PR DESCRIPTION
Removes elastic alerts/notifications.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Disabled disconnection alerts for several subsystems (including drive, elevator, pivot, and roller systems). Users will no longer see notifications when connectivity issues occur on these components, providing a more streamlined alert experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->